### PR TITLE
BUG Class 'plxMyMultiLingue' introuvable quant Multilingue absent

### DIFF
--- a/config.php
+++ b/config.php
@@ -9,9 +9,10 @@ $aLangs = array($plxAdmin->aConf['default_lang']);
 
 # Si le plugin plxMyMultiLingue est installé on filtre sur les langues utilisées
 # On garde par défaut le fr si aucune langue sélectionnée dans plxMyMultiLingue
-$langs = plxMyMultiLingue::_Langs();
-$multiLangs = empty($langs) ? array() : explode(',', $langs);
-$aLangs = $multiLangs;
+if(defined('PLX_MYMULTILINGUE')) {
+	$langs = plxMyMultiLingue::_Langs();
+	$aLangs = empty($langs) ? array() : explode(',', $langs);
+}
 
 if(!empty($_POST)) {
 	$plxPlugin->setParam('mnuDisplay', $_POST['mnuDisplay'], 'numeric');


### PR DESCRIPTION
Fatal error: Class 'plxMyMultiLingue' not found in plxMyContact/config.php on line 12

Et simplifié ;) (il me semble)